### PR TITLE
Fix label for new cert-manager schema

### DIFF
--- a/deploy/cert-manager-webhook-pdns/templates/apiservice.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/apiservice.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "cert-manager-webhook-pdns.servingCertificate" . }}"
-    cert-manager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "cert-manager-webhook-pdns.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "cert-manager-webhook-pdns.servingCertificate" . }}"
 spec:
   group: {{ .Values.groupName }}
   groupPriorityMinimum: 1000


### PR DESCRIPTION
Saw a small typo, so removed the redundant `.k8s` part (looking at the [docs](https://docs.cert-manager.io/en/release-0.11/reference/cainjector.html))
